### PR TITLE
Change - Silence deprecation warnings

### DIFF
--- a/lib/puppet/type/zypprepo.rb
+++ b/lib/puppet/type/zypprepo.rb
@@ -50,7 +50,7 @@ module Puppet
   # Doc string for properties that can be made 'absent'
   ABSENT_DOC="Set this to `absent` to remove it from the file completely."
 
-  newtype(:zypprepo) do
+  Puppet::Type.newtype :zypprepo, :is_capability => true do
     @doc = "The client-side description of a zypper repository. Repository
       configurations are found by parsing `/etc/zypp/zypper.conf` and
       the files indicated by the `reposdir` option in that file


### PR DESCRIPTION
Puppet.newtype is deprecated and will be removed in a future release.
Updated to use Puppet::Type.newtype instead.